### PR TITLE
Docs update

### DIFF
--- a/docs/specification/Protocol.md
+++ b/docs/specification/Protocol.md
@@ -96,6 +96,13 @@ action is encountered, then it **MUST** be created in the local key store.
 If the `provider` was found, the `SignedMessage` that encapsulates this Action 
 must be signed by the same provider (or the Super Provider, if applicable).
 
+An `AppendKey` action **MAY** contain a `limited` field, which must be boolean.
+If it is absent, it is implicitly false. The first `AppendKey` for a provider
+**MUST NOT** have `limited` set to `TRUE`.
+ 
+The provider must have at least one non-limited, non-revoked key in order to
+create limited keys.
+
 When this action is performed, it should insert a new row in a database.
 
 ### RevokeKey
@@ -161,3 +168,32 @@ correct provider (or the Super Provider, if applicable).
 
 When this action is performed, it should update an existing row in a database
 to mark the row as revoked.
+
+### AttestUpdate
+
+A `AttestUpdate` action **MUST** contain the following fields:
+
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `verb`        | Must be `AttestUpdate`.                  |
+| `provider`    | Provider name.                           |
+| `package`     | Name of the package (owned by provider). |
+| `release`     | Version of the package in question.      |
+| `attestation` | See below.                               |
+
+If the `provider` is not found in the local key store when an `RevokeUpdate`
+action is encountered, an error **MUST** be raised. In most languages, this
+means throwing an Exception.
+
+An attestation is a NOP for the purposes of Gossamer's goals (key management
+and code-signing). However, other protocols **MAY** wish to use
+attestations in order to provide third-party oversight into the protocol.
+
+Attestations **MUST** be one of the following:
+
+| Attestation  | Meaning                                                              |
+|--------------|----------------------------------------------------------------------|
+| `reproduced` | The attestor was able to reproduce this update from the source code. |
+| `spot-check` | The attestor provided a spot check for this update.                  |
+| `reviewed`   | The attestor performed a code review for this update.                |
+| `sec-audit`  | This update passed a security audit performed by the attestor.       |

--- a/docs/specification/Protocol.md
+++ b/docs/specification/Protocol.md
@@ -197,3 +197,52 @@ Attestations **MUST** be one of the following:
 | `spot-check` | The attestor provided a spot check for this update.                  |
 | `reviewed`   | The attestor performed a code review for this update.                |
 | `sec-audit`  | This update passed a security audit performed by the attestor.       |
+
+## Invalid Messages in the Ledger
+
+Any records in the ledger that do not contain a valid JSON message 
+must be skipped.
+
+Any records in the ledger that contain a valid JSON message, but
+do not contain a `verb` field conforming to one of the actions defined in
+this specification, must be skipped.
+
+The above two rules allow a single ledger instance to be used for
+multiple purposes without interfering with the normal operation of the
+Gossamer protocol.
+
+### Validation
+
+Any records that contain a JSON message and a `verb` field
+conforming to an action, but are somehow invalid (as defined by the rules
+of each particular `verb`; e.g. missing a mandatory field) but **NOT**
+malicious (e.g. not violating a rule about who can author an `AppendKey`), 
+**MAY** be skipped, but the discrepancy **SHOULD** also be logged.
+
+Alternatively, this can be a protocol error until the operator manually
+skips the invalid message by fast-forwarding to the next ledger record.
+
+### Security
+
+Any records that obey the JSON message rules but violate the security 
+requirements of an action (e.g. trying to append an update for a different
+provider, except if issued by the Super Provider) must constitute a protocol 
+error.
+
+### Protocol Error Handling
+ 
+The protocol will be stopped until a manual action is performed. 
+
+To recover, an operator **MUST** discard the malicious message in order and
+fast-forward to the next ledger record. The operator **SHOULD** investigate
+the cause of the breakage to ensure they are not the subject of a targeted 
+attack.
+ 
+In the event of a network attack that led to invalid records being
+replicated, operators **MAY** empty their keystore and replay the entire
+protocol from the first record once they are sure the network is consistent
+and trustworthy.
+
+Tooling **SHOULD** be provided to allow an operator to specify the new
+savepoint (summary hash, Merkle root, etc.) for the cryptographic ledger
+powering the Gossamer protocol.


### PR DESCRIPTION
* Specify an `AttestUpdate` verb to allow code review and "reproducible build" automation to be published on a Chronicle.
* Specify how errors should be handled in Gossamer.