### PR TITLE
Allow various cryptographic backends in protocol signing

### DIFF
--- a/docs/reference/CryptoBackendInterface.md
+++ b/docs/reference/CryptoBackendInterface.md
@@ -1,6 +1,6 @@
 # CryptoBackendInterface
 
-* **Fully Qualified Interface Name**: `ParagonIE\Gossamer\Release\CryptoBackendInterface`
+* **Fully Qualified Interface Name**: `ParagonIE\Gossamer\CryptoBackendInterface`
 
 ## Interface Methods
 

--- a/docs/reference/CryptoBackends/README.md
+++ b/docs/reference/CryptoBackends/README.md
@@ -1,9 +1,13 @@
-# Backends
+# CryptoBackends
 
 This contains the code to integrate libgossamer with various cryptography
-backends that provide cryptographic signatures. This allows projects to
-extend the [Signer](../Release/Signer.md) and [Verifier](../Release/Verifier.md) classes
-to support Hardware Security Modules (HSMs).
+backends that provide cryptographic signatures.
+ 
+This allows projects to extend the [Signer](../Release/Signer.md) and
+[Verifier](../Release/Verifier.md) classes to support Hardware Security
+Modules (HSMs).
+
+CryptoBackends can also be used with protocol signing.
 
 We ship with a single backend (`SodiumBackend`) which uses Libsodium to
 provide Ed25519 signatures of the hashes of release files.

--- a/docs/reference/CryptoBackends/README.md
+++ b/docs/reference/CryptoBackends/README.md
@@ -2,7 +2,7 @@
 
 This contains the code to integrate libgossamer with various cryptography
 backends that provide cryptographic signatures. This allows projects to
-extend the [Signer](../Signer.md) and [Verifier](../Verifier.md) classes
+extend the [Signer](../Release/Signer.md) and [Verifier](../Release/Verifier.md) classes
 to support Hardware Security Modules (HSMs).
 
 We ship with a single backend (`SodiumBackend`) which uses Libsodium to

--- a/docs/reference/CryptoBackends/SodiumBackend.md
+++ b/docs/reference/CryptoBackends/SodiumBackend.md
@@ -1,6 +1,6 @@
 # SodiumBackend
 
-* **Fully Qualified Class Name**: `ParagonIE\Gossamer\Release\Backend\SodiumBackend`
+* **Fully Qualified Class Name**: `ParagonIE\Gossamer\CryptoBackends\SodiumBackend`
 
 ## Class Methods
 

--- a/docs/reference/Protocol/SignedMessage.md
+++ b/docs/reference/Protocol/SignedMessage.md
@@ -38,6 +38,8 @@
 1. `string` - Contents
 2. `string` - Provider
 3. `string` - Secret Key
+4. [`CryptoProviderBackend`](../CryptoBackendInterface.md) -
+   Optional cryptographic backend. Defaults to [SodiumBackend](../CryptoBackends/SodiumBackend.md).
 
 **Returns** a `SignedMessage` object.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -5,6 +5,8 @@ writing code that needs to use the library.
 
 ## Classes
 
+* [Backends](CryptoBackends)
+  * [SodiumBackend](CryptoBackends/SodiumBackend.md)
 * [Db](Db)
   * [PDO](Db/PDO.md)
 * [Http](Http)
@@ -15,10 +17,7 @@ writing code that needs to use the library.
   * [Packet](Protocol/Packet.md)
   * [SignedMessage](Protocol/SignedMessage.md)
 * [Release](Release)
-  * [Backends](Release/Backends)
-    * [SodiumBackend](Release/Backends/SodiumBackend.md)
   * [Common](Release/Common.md)
-  * [CryptoBakendInterface](Release/CryptoBackendInterface.md)
   * [Signer](Release/Signer.md)
   * [Verifier](Release/Verifier.md)
 * [Scribe](Scribe)
@@ -28,6 +27,7 @@ writing code that needs to use the library.
 * [Verifier](Verifier)
   * [Chronicle](Verifier/Chronicle.md)
 * [DbInterface](DbInterface.md)
+* [CryptoBakendInterface](CryptoBackendInterface.md)
 * [GossamerException](GossmerException.md)
 * [HttpInterface](HttpInterface.md)
 * [LedgerInterface](LedgerInterface.md)

--- a/docs/reference/Release/Common.md
+++ b/docs/reference/Release/Common.md
@@ -14,8 +14,8 @@
 **Arguments**:
 
 1. `int` Algorithm (see [Class Constants](#class-constants))
-2. [`CryptoBackendInterface`](CryptoBackendInterface.md) Optional backend.
-   Defaults to [SodiumBackend](Backends/SodiumBackend.md).
+2. [`CryptoBackendInterface`](../CryptoBackendInterface.md) Optional backend.
+   Defaults to [SodiumBackend](../CryptoBackends/SodiumBackend.md).
 
 ## Static Methods
 

--- a/docs/reference/Release/README.md
+++ b/docs/reference/Release/README.md
@@ -5,9 +5,9 @@ version releases for packages.
 
 ## Classes
 
-* [Backends](Backends)
-    * [SodiumBackend](Backends/SodiumBackend.md)
+* [Backends](../CryptoBackends)
+    * [SodiumBackend](../CryptoBackends/SodiumBackend.md)
 * [Common](Common.md)
-* [CryptoBakendInterface](CryptoBackendInterface.md)
+* [CryptoBakendInterface](../CryptoBackendInterface.md)
 * [Signer](Signer.md)
 * [Verifier](Verifier.md)

--- a/lib/CryptoBackendInterface.php
+++ b/lib/CryptoBackendInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace ParagonIE\Gossamer\Release;
+namespace ParagonIE\Gossamer;
 
 /**
  * Interface CryptoBackendInterface

--- a/lib/CryptoBackends/SodiumBackend.php
+++ b/lib/CryptoBackends/SodiumBackend.php
@@ -1,12 +1,12 @@
 <?php
-namespace ParagonIE\Gossamer\Release\Backends;
+namespace ParagonIE\Gossamer\CryptoBackends;
 
-use ParagonIE\Gossamer\Release\CryptoBackendInterface;
+use ParagonIE\Gossamer\CryptoBackendInterface;
 use ParagonIE\Gossamer\Util;
 
 /**
  * Class SodiumBackend
- * @package ParagonIE\Gossamer\Release\Backends
+ * @package ParagonIE\Gossamer\Release\CryptoBackends
  */
 class SodiumBackend implements CryptoBackendInterface
 {

--- a/lib/Protocol/SignedMessage.php
+++ b/lib/Protocol/SignedMessage.php
@@ -3,6 +3,8 @@ namespace ParagonIE\Gossamer\Protocol;
 
 use ParagonIE\Gossamer\DbInterface;
 use ParagonIE\Gossamer\GossamerException;
+use ParagonIE\Gossamer\CryptoBackends\SodiumBackend;
+use ParagonIE\Gossamer\CryptoBackendInterface;
 use ParagonIE\Gossamer\Util;
 
 /**
@@ -96,13 +98,16 @@ class SignedMessage
      * @param string $contents
      * @param string $provider
      * @param string $secretKey
+     * @param CryptoBackendInterface $backend = null
      * @return SignedMessage
      * @throws \SodiumException
      */
-    public static function sign($contents, $provider, $secretKey)
+    public static function sign($contents, $provider, $secretKey, CryptoBackendInterface $backend = null)
     {
-        $secretKey = Util::rawBinary($secretKey, 64);
-        $sig = sodium_crypto_sign_detached($contents, $secretKey);
+        if (empty($backend)) {
+            $backend = new SodiumBackend();
+        }
+        $sig = $backend->sign($contents, $secretKey);
         return SignedMessage::init(
             $contents,
             sodium_bin2hex($sig),

--- a/lib/Release/Common.php
+++ b/lib/Release/Common.php
@@ -1,8 +1,9 @@
 <?php
 namespace ParagonIE\Gossamer\Release;
 
+use ParagonIE\Gossamer\CryptoBackendInterface;
+use ParagonIE\Gossamer\CryptoBackends\SodiumBackend;
 use ParagonIE\Gossamer\GossamerException;
-use ParagonIE\Gossamer\Release\Backends\SodiumBackend;
 
 /**
  * Class Common
@@ -34,8 +35,10 @@ class Common
      * @throws GossamerException
      * @psalm-suppress InternalMethod
      */
-    public function __construct($alg = self::SIGN_ALG_ED25519_SHA384, CryptoBackendInterface $backend = null)
-    {
+    public function __construct(
+        $alg = self::SIGN_ALG_ED25519_SHA384,
+        CryptoBackendInterface $backend = null
+    ) {
         if (empty($backend)) {
             $backend = new SodiumBackend();
         }


### PR DESCRIPTION
Follow-up to #14 for #10 

This lets you specify a `CryptoBackendInterface` for use in the Gossamer protocol, not just in release signing.